### PR TITLE
Update getting-started.md

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -21,7 +21,7 @@ cd hello-world
 
 Add `actix-web` as a dependency of your project by adding the following to your `Cargo.toml` file.
 
-```toml
+```
 [dependencies]
 actix-web = "{{< actix-version "actix-web" >}}"
 ```


### PR DESCRIPTION
Fix annoying red stuff on content/docs/getting-started.md. See the screenshot below:

<img width="901" alt="Screenshot 2022-10-26 at 04 07 03" src="https://user-images.githubusercontent.com/31823892/197912003-e0b16728-2438-4490-846d-aa3fcb25408c.png">
